### PR TITLE
Seperated create command into self and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ SpongyBackpacks is a simple Sponge plugins that provides backpacks for your play
 
 ## Commands and descriptions
 * /sb create <backpack name> <rows, 1 to 6> [user]: creates a new backpack for you or **user**, if specified.
-    By default, players can only have 2 backpacks, and 2 rows. If you want to change this, just set the option **spongybackpacks.limit.rows/backpacks** to a different value on your permission plugin.
+    By default, players can only have 2 backpacks, and 2 rows. If you want to change this, just set the option **spongybackpacks.limit.backpacks or spongybackpacks.limit.rows respectively** to a different value on your permission plugin.
     Permissions:
-        - spongybackpacks.command.create
+        - spongybackpacks.command.create.own
+        - spongybackpacks.command.create.others
 * /sb open <backpack name> [user]: opens the backpack with this specific name for you or for a player, if specified
     Permissions:
         - spongybackpacks.command.open.own

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 pluginGroup=io.github.eufranio
 pluginId=spongybackpacks
-pluginVersion=1.0
+pluginVersion=1.1


### PR DESCRIPTION
I've separated the create command into separate permissions for self creation, and for when others create it. This means you can now give access to just the self creation to users and not have them able to modify other's backpacks in anyway.

I've also included a readme update to make the permissions more clear, and included one typo fix.


Here are two images after running the create command two different ways:
![image](https://user-images.githubusercontent.com/3313264/94047145-494ea000-fd97-11ea-9235-b18716fda0b6.png)

![image](https://user-images.githubusercontent.com/3313264/94047183-58cde900-fd97-11ea-8344-96e4968a08e8.png)

